### PR TITLE
Include Devise gem number 1.5.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ end
 gem 'jquery-rails'
 
 gem 'will_paginate'
-gem 'devise'
+gem 'devise', '1.5.4'
 gem 'rails_autolink'
 gem 'rake'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,11 +41,10 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.4.0)
-    devise (2.2.1)
+    devise (1.5.4)
       bcrypt-ruby (~> 3.0)
-      orm_adapter (~> 0.1)
-      railties (~> 3.1)
-      warden (~> 1.2.1)
+      orm_adapter (~> 0.0.3)
+      warden (~> 1.1)
     diff-lcs (1.1.3)
     erubis (2.7.0)
     execjs (1.4.0)
@@ -82,7 +81,7 @@ GEM
     method_source (0.8.1)
     mime-types (1.19)
     multi_json (1.2.0)
-    orm_adapter (0.4.0)
+    orm_adapter (0.0.7)
     pg (0.14.1)
     polyglot (0.3.3)
     pry (0.9.10)
@@ -167,7 +166,7 @@ PLATFORMS
 
 DEPENDENCIES
   coffee-rails (~> 3.1.0)
-  devise
+  devise (= 1.5.4)
   execjs
   factory_girl
   factory_girl_rails


### PR DESCRIPTION
Devise 2.0+ no longer includes helpers for migrations.
Running rake db:migrate throws errors or will not work if using devise 2.0.0 or greater
