### PR TITLE
Use `lambda` for named scope

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -33,7 +33,7 @@ class Task < ActiveRecord::Base
     where("name = ? and msg LIKE ?", name ,"%#{URI.encode(filter)}%").order('order_no ASC, updated_at DESC')
   }
 
-  scope :done, where(:status => @@status_table[:done]).order('updated_at DESC')
+  scope :done, lambda { where(:status => @@status_table[:done]).order('updated_at DESC') }
   scope :done_and_filter, lambda {|filter|
     where("status = ? and msg LIKE ?", @@status_table[:done] , "%#{URI.decode(filter)}%").order('updated_at DESC')
   }


### PR DESCRIPTION
`db:migrate` 時に model が読み込まれ、その際に `where(:status => @@status_table[:done])` で SQL が発行されていたため migrate に失敗していた模様です。
`Task.done` を実行するまで SQL を発行しないようにして `rake db:migrate` が失敗しないしようにしました。

おそらく、 ActiveRecord の仕様が変わったことが原因のようです。

Fix #31
