### PR TITLE
Add "addon" section to app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,5 +5,9 @@
   "keywords": ["rails", "kanban", "todo"],
   "scripts": {
     "postdeploy": "rake db:migrate"
-  }
+  },
+  "addons": [
+    "heroku-postgresql:hobby-dev",
+    "sendgrid:starter"
+  ]
 }


### PR DESCRIPTION
SendGrid と PostgreSQL は毎回使いそうだったので、 Heroku にデプロイする際に自動でアドオンが追加されるようにしました。
see for detail: https://devcenter.heroku.com/articles/app-json-schema#addons